### PR TITLE
Exclude datasource auto configuration

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=backend
 server.PORT=9090
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration


### PR DESCRIPTION
Prevents Spring Boot from trying to configure a Datasource so backend can function without a database connection