### PR TITLE
Implement filter, sort and pagiation for todos

### DIFF
--- a/backend/src/main/java/com/todo/backend/dto/TodoFilterRequest.java
+++ b/backend/src/main/java/com/todo/backend/dto/TodoFilterRequest.java
@@ -7,7 +7,6 @@ public class TodoFilterRequest {
     private String search;
     private String priority;
     private Boolean done;
-    private String state;
     private String sortBy = "createdAt";
     private String order = "asc";
     private int page = 0;

--- a/backend/src/main/java/com/todo/backend/service/TodoService.java
+++ b/backend/src/main/java/com/todo/backend/service/TodoService.java
@@ -1,13 +1,19 @@
 package com.todo.backend.service;
 
+import com.todo.backend.dto.TodoFilterRequest;
 import com.todo.backend.model.Todo;
 import com.todo.backend.repository.TodoRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class TodoService implements ITodoService {
@@ -16,8 +22,38 @@ public class TodoService implements ITodoService {
     private TodoRepository todoRepository;
 
     @Override
-    public List<Todo> listTodos() {
-        return todoRepository.findAll();
+    public Page<Todo> getFilteredTodos(TodoFilterRequest filter) {
+        List<Todo> todos = todoRepository.findAll();
+
+        //Filtering
+        List<Todo> filtered = todos.stream()
+                .filter(todo -> filter.getSearch() == null || todo.getTodoText().toLowerCase().contains(filter.getSearch().toLowerCase()))
+                .filter(todo -> filter.getPriority() == null || filter.getPriority().equalsIgnoreCase(todo.getPriority()))
+                .filter(todo -> filter.getDone() == null || filter.getDone().equals(todo.getDone()))
+                .collect(Collectors.toList());
+
+        // Sort
+        Comparator<Todo> comparator = Comparator.comparing(todo -> {
+            return switch (filter.getSortBy()) {
+                case "title" -> todo.getTodoText();
+                case "priority" -> todo.getPriority();
+                case "done" -> todo.getDone().toString();
+                default -> todo.getCreationDate().toString();
+            };
+        });
+
+        if ("desc".equalsIgnoreCase(filter.getOrder())) {
+            comparator = comparator.reversed();
+        }
+
+        filtered.sort(comparator);
+
+        // Pagination
+        int start = filter.getPage() * filter.getSize();
+        int end = Math.min(start + filter.getSize(), filtered.size());
+        List<Todo> pageContent = (start < end) ? filtered.subList(start, end) : List.of();
+
+        return new PageImpl<>(pageContent, PageRequest.of(filter.getPage(), filter.getSize()), filtered.size());
     }
 
     @Override


### PR DESCRIPTION
This PR completes the implementation of "getFilteredTodos" in "TodoService"
The logic supports filtering by Todo name, priority, and done state. 
Also implements sorting and manual pagination on top of an in-memory list.